### PR TITLE
Add Dependabot configuration and update CI to Node.js 20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    target-branch: dev
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: dev

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,19 @@
+name: Auto Assign
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - name: 'Auto-assign issue'
+      uses: pozil/auto-assign-issue@v1
+      with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          assignees: fakedude
+          numOfAssignee: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: 22
+        node-version: 20
 
     - name: Install modules
-      run: yarn
+      run: npm install
 
     - name: Run tests
-      run: yarn test
+      run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-    "name": "stolyarchuk.ton",
-    "version": "0.0.1",
+    "name": "bypass.ton",
+    "version": "0.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "stolyarchuk.ton",
-            "version": "0.0.1",
+            "name": "bypass.ton",
+            "version": "0.0.0",
             "dependencies": {
                 "@ton-community/func-js": "^0.7.0"
             },


### PR DESCRIPTION
This pull request introduces a Dependabot configuration for managing npm and GitHub Actions updates, scheduled for daily and weekly intervals, respectively. Additionally, the CI configuration has been updated to use Node.js 20 and npm for package management, replacing yarn commands. The project name has also been changed to "Bypass" in the package-lock.json file.